### PR TITLE
Refactor `parseAmount`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [[v3.0.2]](https://github.com/multiversx/mx-sdk-dapp-utils/pull/27) - 2025-09-16
+
+- [Refactored parseAmount to mimic sdk-core v.14 implementation](https://github.com/multiversx/mx-sdk-dapp-utils/pull/26)
+
 ## [[v3.0.1]](https://github.com/multiversx/mx-sdk-dapp-utils/pull/25) - 2025-08-05
 
 - [Migrate to sdk-core v15](https://github.com/multiversx/mx-sdk-dapp-utils/pull/22)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-dapp-utils",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "SDK for DApp utilities",
   "main": "out/index.js",
   "types": "out/index.d.js",

--- a/src/helpers/parseAmount.ts
+++ b/src/helpers/parseAmount.ts
@@ -1,14 +1,7 @@
 import BigNumber from 'bignumber.js';
 import { DECIMALS } from '../constants';
 
-export function parseAmount(amount: string, numDecimals: number = DECIMALS) {
-  const amountBN = new BigNumber(amount);
-  const multiplier = new BigNumber(10).pow(numDecimals);
-  const result = amountBN.multipliedBy(multiplier);
-
-  if (!result.isInteger()) {
-    throw new Error('Amount has too many decimal places');
-  }
-
+export function parseAmount(amount: string, numDecimals = DECIMALS): string {
+  const result = new BigNumber(amount).shiftedBy(numDecimals).decimalPlaces(0);
   return result.toFixed(0);
 }


### PR DESCRIPTION
### Issue
Tests in form ar failing because the new implementation of `parseAmount` has slight differences from what was implemented in SDK core version 14

### Fix
Make a new implementation more similar to sdk-core v.14 and keep tests unchanged